### PR TITLE
Add context to confusing error message

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -318,6 +318,7 @@ func (p *processor) send(clientIP net.Addr, reqID uuid.UUID, tenant string, wr *
 	req.SetBody(buf)
 
 	if err = p.cli.DoTimeout(req, resp, p.cfg.Timeout); err != nil {
+		err = fmt.Errorf("failed to perform egress request: %w", err)
 		return
 	}
 


### PR DESCRIPTION
When a timeout happened on the egress the message looked like the timeout comes from the ingress prometheus: `time="2023-10-07T00:07:47Z" level=error msg="proc: src=10.128.6.96:40922 timeout"`.